### PR TITLE
Limit comment number

### DIFF
--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -20,3 +20,7 @@ Image Sources:
 * Bear Icon: https://lh3.googleusercontent.com/proxy/5vM4XEamw9xc3aV5kW9TXH6GKQGGUpJJmbnA7FS-nTb6HqET2xgvgYM6XlcVyx3P4JV51U72cTSZyYJmc9nBv-3fdfxJRJbBN7p_TzBqB5CiO1hUFi_X
 
 All other images are my own.
+
+
+Coding Sources:
+* I used this source as a guide to formatting date and time on the Comments tab: https://beginnersbook.com/2013/05/java-date-string-conversion/

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -23,4 +23,8 @@ All other images are my own.
 
 
 Coding Sources:
-* I used this source as a guide to formatting date and time on the Comments tab: https://beginnersbook.com/2013/05/java-date-string-conversion/
+* I used this source as a guide to formatting date and time on the Comments tab: 
+    * https://beginnersbook.com/2013/05/java-date-string-conversion/
+* These two sources helped with formatting the timestamp of each comment:
+    * https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
+    * https://dzone.com/articles/java-simpledateformat-guide

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -23,6 +23,11 @@
       <version>4.0.1</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -28,12 +28,12 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
-  <dependency>
-    <groupId>com.google.appengine</groupId>
-    <artifactId>appengine-api-1.0-sdk</artifactId>
-    <version>1.9.59</version>
-  </dependency>
 
   <build>
     <plugins>

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -29,6 +29,11 @@
       <version>2.8.6</version>
     </dependency>
   </dependencies>
+  <dependency>
+    <groupId>com.google.appengine</groupId>
+    <artifactId>appengine-api-1.0-sdk</artifactId>
+    <version>1.9.59</version>
+  </dependency>
 
   <build>
     <plugins>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -40,7 +40,8 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void init() {
-      df = new SimpleDateFormat("dd/MM/yyyy, HH:mm");
+      df = new SimpleDateFormat("MMMMM d, yyyy h:mm a z");
+      df.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
       datastore = DatastoreServiceFactory.getDatastoreService();
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -21,16 +21,20 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
   private List<List<String>> comments;
+  DateFormat df;
 
   @Override
   public void init() {
       comments = new ArrayList<>();
+      df = new SimpleDateFormat("dd/MM/yyyy, HH:mm");
   }
 
   @Override
@@ -44,10 +48,14 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     List<String> entry = new ArrayList<>();
+
     String name = getParameter(request, "name", "Anonymous");
     String comment = getParameter(request, "comment", "[Empty Message]");
+    Date entryDate = new Date();
     entry.add(name);
     entry.add(comment);
+    entry.add(df.format(entryDate));
+
     comments.add(entry);
     response.sendRedirect("/index.html");
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -24,6 +24,17 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
+  private List<String> messages;
+
+  @Override
+  public void init() {
+      messages = new ArrayList<>();
+      messages.add("Bears in my hair");
+      messages.add("I got tha");
+      messages.add("NYC -> HR, OR");
+  }
+
+
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     response.setContentType("text/html;");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -26,28 +26,41 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
-  private List<String> messages;
+  private List<String> comments;
 
   @Override
   public void init() {
-      messages = new ArrayList<>();
-      messages.add("Bears in my hair");
-      messages.add("I got tha");
-      messages.add("NYC -> HR, OR");
+      comments = new ArrayList<>();
   }
-
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String json = convertToJsonUsingGson(messages);
+    String json = convertToJsonUsingGson(comments);
 
     response.setContentType("application/json;");
     response.getWriter().println(json);
   }
 
-  private String convertToJsonUsingGson(List<String> messages) {
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String name = getParameter(request, "name", "Anonymous");
+    String comment = getParameter(request, "comment", "[Empty Message]");
+    comments.add(name);
+    comments.add(comment);
+    response.sendRedirect("/index.html");
+  }
+
+  private String getParameter(HttpServletRequest request, String paramName, String defaultValue) {
+    String value = request.getParameter(paramName);
+    if (value == null) {
+      return defaultValue;
+    }
+    return value;
+  }
+
+  private String convertToJsonUsingGson(List<String> comments) {
     Gson gson = new Gson();
-    String json = gson.toJson(messages);
+    String json = gson.toJson(comments);
     System.out.println(json);
     return json;
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -27,6 +27,6 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     response.setContentType("text/html;");
-    response.getWriter().println("<h1>Hello world!</h1>");
+    response.getWriter().println("<h1>Hello Tommy!</h1>");
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,6 +14,9 @@
 
 package com.google.sps.servlets;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
 import java.io.IOException;
 import java.util.*;
 import com.google.gson.Gson;
@@ -29,12 +32,14 @@ import java.text.SimpleDateFormat;
 public class DataServlet extends HttpServlet {
 
   private List<List<String>> comments;
-  DateFormat df;
+  private DateFormat df;
+  private DatastoreService datastore;
 
   @Override
   public void init() {
-      comments = new ArrayList<>();
+      // comments = new ArrayList<>();
       df = new SimpleDateFormat("dd/MM/yyyy, HH:mm");
+      datastore = DatastoreServiceFactory.getDatastoreService();
   }
 
   @Override
@@ -47,16 +52,21 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    List<String> entry = new ArrayList<>();
+    // List<String> entry = new ArrayList<>();
 
-    String name = getParameter(request, "name", "Anonymous");
-    String comment = getParameter(request, "comment", "[Empty Message]");
-    Date entryDate = new Date();
-    entry.add(name);
-    entry.add(comment);
-    entry.add(df.format(entryDate));
+    String author = getParameter(request, "name", "Anonymous");
+    String message = getParameter(request, "message", "[Empty Message]");
+    String date = df.format(new Date());
+    // entry.add(name);
+    // entry.add(comment);
+    // entry.add(df.format(entryDate));
 
-    comments.add(entry);
+    Entity comment = new Entity("Comment");
+    comment.setProperty("author", author);
+    comment.setProperty("message", message);
+    comment.setProperty("date", date);
+
+    datastore.put(comment);
     response.sendRedirect("/index.html");
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -19,6 +19,8 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.FetchOptions;
 import java.io.IOException;
 import java.util.*;
 import com.google.gson.Gson;
@@ -44,10 +46,11 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    PreparedQuery comments = datastore.prepare(new Query("Comment").addSort("timestamp"));
+    PreparedQuery comments = datastore.prepare(new Query("Comment").addSort("timestamp", SortDirection.DESCENDING));
+    int maxComments = Integer.parseInt(request.getParameter("max-comments"));
 
     List<List<String>> commentsList = new ArrayList<>();
-    for (Entity entity : comments.asIterable()) {
+    for (Entity entity : comments.asIterable(FetchOptions.Builder.withLimit(maxComments))) {
       List<String> comment = new ArrayList<>();
       comment.add((String) entity.getProperty("author"));
       comment.add((String) entity.getProperty("message"));
@@ -62,7 +65,7 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String author = getParameter(request, "name", "Anonymous");
+    String author = getParameter(request, "author", "Anonymous");
     String message = request.getParameter("message");
     long timestamp = System.currentTimeMillis();
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -15,6 +15,8 @@
 package com.google.sps.servlets;
 
 import java.io.IOException;
+import java.util.*;
+import com.google.gson.Gson;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -37,7 +39,16 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
-    response.getWriter().println("<h1>Hello Tommy!</h1>");
+    String json = convertToJsonUsingGson(messages);
+
+    response.setContentType("application/json;");
+    response.getWriter().println(json);
+  }
+
+  private String convertToJsonUsingGson(List<String> messages) {
+    Gson gson = new Gson();
+    String json = gson.toJson(messages);
+    System.out.println(json);
+    return json;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
-  private List<String> comments;
+  private List<List<String>> comments;
 
   @Override
   public void init() {
@@ -43,22 +43,24 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    List<String> entry = new ArrayList<>();
     String name = getParameter(request, "name", "Anonymous");
     String comment = getParameter(request, "comment", "[Empty Message]");
-    comments.add(name);
-    comments.add(comment);
+    entry.add(name);
+    entry.add(comment);
+    comments.add(entry);
     response.sendRedirect("/index.html");
   }
 
   private String getParameter(HttpServletRequest request, String paramName, String defaultValue) {
     String value = request.getParameter(paramName);
-    if (value == null) {
+    if (value.equals("")) {
       return defaultValue;
     }
     return value;
   }
 
-  private String convertToJsonUsingGson(List<String> comments) {
+  private String convertToJsonUsingGson(List<List<String>> comments) {
     Gson gson = new Gson();
     String json = gson.toJson(comments);
     System.out.println(json);

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -115,10 +115,11 @@
         <h3>Comments</h3>
         <p>Submit your own comment below!</p>
         <form action="/data" method="POST">
-          <label for="name">Name:</label><br> 
-          <input type="text" id="name" name="name"><br></br>
-          <label for="comment">Message:</label><br>
+          <label for="author">Name:</label><br> 
+          <input type="text" id="author" name="author"><br></br>
+          <label for="message">Message:</label><br>
           <input type="text" id="message" name="message"></br></br>
+          <input type="number" id="max-comments" name="max-comments" min="0" value="5"></br></br>
           <input type="submit" id="submit"/>
         </form>
       </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -117,8 +117,8 @@
         <form action="/data" method="POST">
           <label for="name">Name:</label><br> 
           <input type="text" id="name" name="name"><br></br>
-          <label for="comment">Comment:</label><br>
-          <input type="text" id="comment" name="comment"></br></br>
+          <label for="comment">Message:</label><br>
+          <input type="text" id="message" name="message"></br></br>
           <input type="submit" id="submit"/>
         </form>
       </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -119,9 +119,10 @@
           <input type="text" id="author" name="author"><br></br>
           <label for="message">Message:</label><br>
           <input type="text" id="message" name="message"></br></br>
-          <input type="number" id="max-comments" name="max-comments" min="0" value="5"></br></br>
+          <input type="number" id="max-comments" name="max-comments" min="0" value="5" onchange="fetchMessages(value)"></br></br>
           <input type="submit" id="submit"/>
         </form>
+        <div id="comments-container"></div>
       </div>
       
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -113,12 +113,13 @@
 
       <div id="Comments" class="tab-info">
         <h3>Comments</h3>
+        <p>Submit your own comment below!</p>
         <form action="/data" method="POST">
           <label for="name">Name:</label><br> 
-          <input type="text" id="name" name="name"><br>
+          <input type="text" id="name" name="name"><br></br>
           <label for="comment">Comment:</label><br>
-          <input type="text" id="comment" name="comment"></br>
-          <input type="submit"/>
+          <input type="text" id="comment" name="comment"></br></br>
+          <input type="submit" id="submit"/>
         </form>
       </div>
       

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -113,7 +113,6 @@
 
       <div id="Comments" class="tab-info">
         <h3>Comments</h3>
-        <p id=comment-placeholder></p>
       </div>
       
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -23,6 +23,7 @@
         <button class="tab-button" onclick="displayTab(event, 'Interests')">My Interests</button>
         <button class="tab-button" onclick="displayTab(event, 'Bucket List')">My Bucket List</button>
         <button class="tab-button" onclick="displayTab(event, 'Gallery')">Gallery</button>
+        <button class="tab-button" onclick="displayTab(event, 'Comments')">Comments</button>
       </div>
       
       <div id="About Me" class="tab-info">
@@ -108,6 +109,10 @@
           <a href="images/tampa.jpg"><img src="images/tampa.jpg"/></a>
           <a href="images/lucas.jpg"><img src="images/lucas.jpg"/></a>
         </div>
+      </div>
+
+      <div id="Comments" clas="tab-info">
+        <h3>Comments</h3>
       </div>
       
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -111,8 +111,9 @@
         </div>
       </div>
 
-      <div id="Comments" clas="tab-info">
+      <div id="Comments" class="tab-info">
         <h3>Comments</h3>
+        <p id=comment-placeholder></p>
       </div>
       
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -119,9 +119,9 @@
           <input type="text" id="author" name="author"><br></br>
           <label for="message">Message:</label><br>
           <input type="text" id="message" name="message"></br></br>
-          <input type="number" id="max-comments" name="max-comments" min="0" value="5" onchange="fetchMessages(value)"></br></br>
           <input type="submit" id="submit"/>
         </form>
+        <input type="number" id="max-comments" name="max-comments" min="0" value="5" onchange="fetchComments(value)"></br></br>
         <div id="comments-container"></div>
       </div>
       

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -113,6 +113,13 @@
 
       <div id="Comments" class="tab-info">
         <h3>Comments</h3>
+        <form action="/data" method="POST">
+          <label for="name">Name:</label><br> 
+          <input type="text" id="name" name="name"><br>
+          <label for="comment">Comment:</label><br>
+          <input type="text" id="comment" name="comment"></br>
+          <input type="submit"/>
+        </form>
       </div>
       
     </div>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -191,5 +191,5 @@ function fetchMessages() {
 function createParagraph(message) {
     const pElement = document.createElement('p');
     pElement.innerText = message;
-    return pElementl
+    return pElement;
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -41,7 +41,7 @@ function displayTab(event, tabName) {
     }
 
     if (tabName === "Comments") {
-        fetchMessages(document.getElementById("max-comments").value);
+        fetchComments(document.getElementById("max-comments").value);
     }
 }
 
@@ -176,7 +176,7 @@ function resetEasterEgg() {
 /**
  * Fetches a comment using DataServlet.java.
  */
-function fetchMessages(maxComments) {
+function fetchComments(maxComments) {
     fetch('/data?max-comments=' + maxComments).then(response => response.json()).then((entries) => {
         var commentsContainer = document.getElementById('comments-container');
         commentsContainer.innerHTML = '';

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -41,7 +41,7 @@ function displayTab(event, tabName) {
     }
 
     if (tabName === "Comments") {
-        fetchComment();
+        fetchMessages();
     }
 }
 
@@ -176,8 +176,11 @@ function resetEasterEgg() {
 /**
  * Fetches a comment using DataServlet.java.
  */
-function fetchComment() {
-    fetch('/data').then(response => response.text()).then((comment) => {
-        document.getElementById('comment-placeholder').innerText = comment;
+function fetchMessages() {
+    fetch('/data').then(response => response.json()).then((messages) => {
+        const commentTab = document.getElementById('Comments');
+        for (var i = 0; i < messages.length; i++) {
+            commentTab.appendChild(createParagraph(messages[i]));
+        }
     });
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -179,6 +179,7 @@ function resetEasterEgg() {
 function fetchMessages() {
     fetch('/data').then(response => response.json()).then((messages) => {
         const commentTab = document.getElementById('Comments');
+        console.log(messages);
         for (var i = 0; i < messages.length; i++) {
             commentTab.appendChild(createParagraph(messages[i]));
         }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -36,8 +36,12 @@ function displayTab(event, tabName) {
     document.getElementById(tabName).style.display = "block";
     event.currentTarget.className += " active";
 
-    if (tabName == "Interests"){
+    if (tabName === "Interests") {
         drawTimeline();
+    }
+
+    if (tabName === "Comments") {
+        fetchComment();
     }
 }
 
@@ -167,4 +171,13 @@ function easterEgg() {
 function resetEasterEgg() {
     var headshot = document.getElementById("headshot");
     headshot.src = "/images/beta-headshot.jpg";
+}
+
+/**
+ * Fetches a comment using DataServlet.java.
+ */
+function fetchComment() {
+    fetch('/data').then(response => response.text()).then((comment) => {
+        document.getElementById('comment-placeholder').innerText = comment;
+    });
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -177,7 +177,7 @@ function resetEasterEgg() {
  * Fetches a comment using DataServlet.java.
  */
 function fetchMessages() {
-    fetch('/data').then(response => response.json()).then((entries) => {
+    fetch('/data?max-comments=5').then(response => response.json()).then((entries) => {
         const commentTab = document.getElementById('Comments');
         const numComments = commentTab.getElementsByClassName("comment").length;
         for (var i = numComments; i < entries.length; i++) {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -204,7 +204,6 @@ function fetchComments(maxComments) {
     fetch('/data?max-comments=' + maxComments).then(response => response.json()).then((entries) => {
         var commentsContainer = document.getElementById('comments-container');
         commentsContainer.innerHTML = '';
-        const numComments = commentsContainer.getElementsByClassName('comment').length;
         for (var i = 0; i < entries.length; i++) {
             commentsContainer.appendChild(createComment(entries[i]));
         }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -184,3 +184,12 @@ function fetchMessages() {
         }
     });
 }
+
+/**
+ * Creates a <p> element with the given message.
+ */
+function createParagraph(message) {
+    const pElement = document.createElement('p');
+    pElement.innerText = message;
+    return pElementl
+}

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -193,15 +193,15 @@ function createComment(entry) {
     const commentDiv = document.createElement('div');
     const author = document.createElement('p');
     const message = document.createElement('p')
-    const date = document.createElement('p');
 
-    author.innerText = entry[0];
+    author.innerText = entry[0] + " (" + entry[2] + ")";
+    author.id = "author";
+
     message.innerText = entry[1];
-    date.innerText = entry[2];
+    message.id = "message";
     
     commentDiv.appendChild(author);
     commentDiv.appendChild(message);
-    commentDiv.appendChild(date);
     commentDiv.className = "comment";
     return commentDiv;
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -41,7 +41,7 @@ function displayTab(event, tabName) {
     }
 
     if (tabName === "Comments") {
-        fetchMessages();
+        fetchMessages(document.getElementById("max-comments").value);
     }
 }
 
@@ -176,12 +176,13 @@ function resetEasterEgg() {
 /**
  * Fetches a comment using DataServlet.java.
  */
-function fetchMessages() {
-    fetch('/data?max-comments=5').then(response => response.json()).then((entries) => {
-        const commentTab = document.getElementById('Comments');
-        const numComments = commentTab.getElementsByClassName("comment").length;
-        for (var i = numComments; i < entries.length; i++) {
-            commentTab.appendChild(createComment(entries[i]));
+function fetchMessages(maxComments) {
+    fetch('/data?max-comments=' + maxComments).then(response => response.json()).then((entries) => {
+        var commentsContainer = document.getElementById('comments-container');
+        commentsContainer.innerHTML = '';
+        const numComments = commentsContainer.getElementsByClassName('comment').length;
+        for (var i = 0; i < entries.length; i++) {
+            commentsContainer.appendChild(createComment(entries[i]));
         }
     });
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -177,11 +177,11 @@ function resetEasterEgg() {
  * Fetches a comment using DataServlet.java.
  */
 function fetchMessages() {
-    fetch('/data').then(response => response.json()).then((messages) => {
+    fetch('/data').then(response => response.json()).then((entries) => {
         const commentTab = document.getElementById('Comments');
-        console.log(messages);
-        for (var i = 0; i < messages.length; i++) {
-            commentTab.appendChild(createParagraph(messages[i]));
+        const numComments = commentTab.getElementsByClassName("comment").length;
+        for (var i = numComments; i < entries.length; i++) {
+            commentTab.appendChild(createComment(entries[i]));
         }
     });
 }
@@ -189,8 +189,19 @@ function fetchMessages() {
 /**
  * Creates a <p> element with the given message.
  */
-function createParagraph(message) {
-    const pElement = document.createElement('p');
-    pElement.innerText = message;
-    return pElement;
+function createComment(entry) {
+    const commentDiv = document.createElement('div');
+    const author = document.createElement('p');
+    const message = document.createElement('p')
+    const date = document.createElement('p');
+
+    author.innerText = entry[0];
+    message.innerText = entry[1];
+    date.innerText = entry[2];
+    
+    commentDiv.appendChild(author);
+    commentDiv.appendChild(message);
+    commentDiv.appendChild(date);
+    commentDiv.className = "comment";
+    return commentDiv;
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -86,6 +86,7 @@ ul {
   outline: none;
   padding: 14px 16px;
   transition: .3s;
+  width: 20%;
 }
 
 .tabs button:hover {
@@ -123,8 +124,8 @@ ul {
 .tab-button {
   color: #e4f5ff;
   font-size: 30px;
-  margin-left: 50px;
-  margin-right: 50px;
+  margin-left: 20px;
+  margin-right: 20px;
 }
 
 .more-info {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -239,9 +239,49 @@ ul {
   border: thick solid #64a7f5;
 }
 
+label {
+  color: #054f7d;
+  margin-bottom: 4px;
+  font-size: 20px;
+}
+
+input {
+  background-color: #fff;
+  border: 2px solid #054f7d;
+  border-radius: 5px;
+  color: #64a7f5;
+  font-family: 'Oxygen';
+  font-size: 20px;
+  height: 30%;
+  width: 30%;
+}
+
+input:hover {
+  border-color: #64a7f5;
+}
+
+#comment {
+  width: 70%;
+}
+
+#submit {
+  background-color: #054f7d;
+  border-color: #64a7f5;
+  color: #e4f5ff;
+  font-size: 25px;
+  height: 50px;
+  text-align: center;
+  transition: .3s;
+  width: 100px;
+}
+
+#submit:hover {
+  background-color: #64a7f5;
+}
+
 .comment {
   margin: 15px 15px 15px 15px;
-  background-color: #c4e9ff;
+  background-color: #f1faff;
   border: thick solid #054f7d;
   border-radius: 10px;
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -241,7 +241,6 @@ ul {
 
 label {
   color: #054f7d;
-  margin-bottom: 4px;
   margin-left: 10px;
   font-size: 20px;
 }
@@ -253,6 +252,7 @@ input {
   color: #64a7f5;
   font-family: 'Oxygen';
   font-size: 20px;
+  margin-left: 10px;
   width: 30%;
 }
 

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -86,7 +86,6 @@ ul {
   outline: none;
   padding: 14px 16px;
   transition: .3s;
-  width: 20%;
 }
 
 .tabs button:hover {
@@ -238,5 +237,24 @@ ul {
 
 .image-thumbnails img:hover {
   border: thick solid #64a7f5;
+}
+
+.comment {
+  margin: 15px 15px 15px 15px;
+  background-color: #c4e9ff;
+  border: thick solid #054f7d;
+  border-radius: 10px;
+}
+
+#author {
+  margin: 10px 10px 5px 10px;
+  color: #054f7d;
+  font-size: 20px;
+}
+
+#message {
+  margin: 0px 10px 10px 10px;
+  color: #64a7f5;
+  font-size: 30px;
 }
 

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -242,6 +242,7 @@ ul {
 label {
   color: #054f7d;
   margin-bottom: 4px;
+  margin-left: 10px;
   font-size: 20px;
 }
 
@@ -252,16 +253,11 @@ input {
   color: #64a7f5;
   font-family: 'Oxygen';
   font-size: 20px;
-  height: 30%;
   width: 30%;
 }
 
 input:hover {
   border-color: #64a7f5;
-}
-
-#comment {
-  width: 70%;
 }
 
 #submit {
@@ -270,6 +266,7 @@ input:hover {
   color: #e4f5ff;
   font-size: 25px;
   height: 50px;
+  margin-left: 10px;
   text-align: center;
   transition: .3s;
   width: 100px;


### PR DESCRIPTION
This PR adds the ability to control the number of comments that are displayed on the comments tab. The user controls the value of a number input HTML element, which is then passed into the fetch() method as a parameter in the GET request query string. The GET request then responds with only the specified number of comments. To immediately adjust the number of comments shown, the number input HTML element calls the fetch() method via the onchange attribute, so the correct number of comments are shown as soon as it's specified by the user.